### PR TITLE
Backend/adjust length limitations in config

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -1,5 +1,3 @@
-
-
 export enum VOTE_OPTIONS_ENUM { // allowed options for vote request
   LIKE = 'like',
   DISLIKE = 'dislike',
@@ -11,16 +9,15 @@ export const VOTE_OPTIONS = [
   VOTE_OPTIONS_ENUM.NONE,
 ];
 
-export const TAG_LIMIT: number = 5; // number of tags per question
-export const AI_LIMIT: number = 15;
+export const TAG_LIMIT: number = 5; // number of tags returned per request
+export const AI_LIMIT: number = 15; // max number of ai answers for non-pro users
+export const EXPORT_LIMIT: number = 10; // max amount of questions returned in requests
 
-export const TEXT_LENGTH: number = 4_294_967_200; // letters per request // LONGTEXT
-export const TAG_LENGTH: number = 50; //  letters per text //VARCHAR(191)
-export const TITLE_LENGTH: number = 190; //  letters per text // VARCHAR(191)
-
-export const TAG_SEARCH_LENGTH_LIMIT: number = 51; // letters in request
-
-export const EXPORT_LIMIT: number = 20; // max amount of questions in request
+// changes in max length also have to be made in file "prisma/schema.prisma"
+export const TEXT_LENGTH: number = 4_294_967_200; // max chars in content (LongText)
+export const TAG_LENGTH: number = 12; //  max chars in tagname
+export const TITLE_LENGTH: number = 50; //  max chars in title
+export const USERNAME_LENGTH: number = 20; //  max chars in username
 
 // sort parameters
 

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -5,16 +5,20 @@ export enum VOTE_OPTIONS_ENUM { // allowed options for vote request
   DISLIKE = 'dislike',
   NONE = 'none',
 }
-export const VOTE_OPTIONS = [VOTE_OPTIONS_ENUM.LIKE, VOTE_OPTIONS_ENUM.DISLIKE, VOTE_OPTIONS_ENUM.NONE]
+export const VOTE_OPTIONS = [
+  VOTE_OPTIONS_ENUM.LIKE,
+  VOTE_OPTIONS_ENUM.DISLIKE,
+  VOTE_OPTIONS_ENUM.NONE,
+];
 
 export const TAG_LIMIT: number = 5; // number of tags per question
 export const AI_LIMIT: number = 15;
 
-export const TEXT_LENGTH: number = 100; // letters per request
-export const TAG_LENGTH: number = 10; //  letters per text
-export const TITLE_LENGTH: number = 15; //  letters per text
+export const TEXT_LENGTH: number = 4_294_967_200; // letters per request // LONGTEXT
+export const TAG_LENGTH: number = 50; //  letters per text //VARCHAR(191)
+export const TITLE_LENGTH: number = 190; //  letters per text // VARCHAR(191)
 
-export const TAG_SEARCH_LENGTH_LIMIT: number = 10; // letters in request
+export const TAG_SEARCH_LENGTH_LIMIT: number = 51; // letters in request
 
 export const EXPORT_LIMIT: number = 20; // max amount of questions in request
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 
 model User {
   userID             String         @id @default(uuid())
-  username           String         @unique
+  username           String         @unique @db.VarChar(20)
   isPro              Boolean        @default(false)
   isAdmin            Boolean        @default(false)
   timeOfRegistration DateTime       @default(now())
@@ -53,7 +53,7 @@ model UserContent {
 model Question {
   userContent   UserContent @relation(fields: [userContentID], references: [userContentID])
   userContentID String      @id
-  title         String
+  title         String      @db.VarChar(50)
 
   @@fulltext([title])
 }
@@ -73,7 +73,7 @@ enum TypeOfAI {
 model Discussion {
   userContent   UserContent   @relation(fields: [userContentID], references: [userContentID])
   userContentID String        @id
-  title         String
+  title         String        @db.VarChar(50)
   isPrivate     Boolean       @default(false)
   userTimeouts  UserTimeout[]
   moderations   Moderation[]
@@ -128,7 +128,7 @@ model Favorite {
 }
 
 model Tag {
-  tagname  String        @id @unique
+  tagname  String        @id @unique @db.VarChar(12)
   experts  Expert[]
   contents UserContent[]
 }

--- a/backend/src/externalAPI/externalAPI.service.spec.ts
+++ b/backend/src/externalAPI/externalAPI.service.spec.ts
@@ -4,6 +4,7 @@ import { HttpModule } from '@nestjs/axios';
 import { PrismaService } from '../database/prisma.service';
 import { UserContentService } from '../database/user-content/user-content.service';
 import { UserService } from '../database/user/user.service';
+import { mockPrisma } from '../database/mockedPrismaClient';
 
 describe('ExternalAPIService', () => {
   let service: ExternalAPIService;
@@ -17,7 +18,10 @@ describe('ExternalAPIService', () => {
         PrismaService,
         UserService,
       ],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrisma)
+      .compile();
 
     service = module.get<ExternalAPIService>(ExternalAPIService);
   });

--- a/backend/src/requests/favourites/favourites.controller.ts
+++ b/backend/src/requests/favourites/favourites.controller.ts
@@ -55,7 +55,7 @@ export class FavouritesController {
   ) {
     const userId = req.userId;
 
-    if (await this.usercontentService.checkUserContentIDExists(id)) {
+    if ((await this.usercontentService.getAnswer(id)) == null) {
       throw new NotFoundException('Question not found!');
     }
 

--- a/backend/src/requests/favourites/favourites.controller.ts
+++ b/backend/src/requests/favourites/favourites.controller.ts
@@ -55,7 +55,7 @@ export class FavouritesController {
   ) {
     const userId = req.userId;
 
-    if ((await this.usercontentService.getAnswer(id)) == null) {
+    if (await this.usercontentService.checkUserContentIDExists(id)) {
       throw new NotFoundException('Question not found!');
     }
 

--- a/backend/src/requests/tag/dto/tagquery.dto.ts
+++ b/backend/src/requests/tag/dto/tagquery.dto.ts
@@ -1,9 +1,9 @@
 import { IsString, MaxLength, MinLength } from 'class-validator';
-import { TAG_SEARCH_LENGTH_LIMIT } from '../../../../config';
+import { TAG_LENGTH } from '../../../../config';
 
 export class TagQuery {
   @IsString()
-  @MaxLength(TAG_SEARCH_LENGTH_LIMIT)
+  @MaxLength(TAG_LENGTH)
   @MinLength(1)
   tag: string;
 }


### PR DESCRIPTION
* changed length limitation for:
    * user-content content,
    * question-title 
    * tag length
  
@MichalskyL should we implement a synchronisation with the database schema and the config
or is this limitation sufficient?